### PR TITLE
[FIX] test ubuntu version to set OpenCV path accordingly

### DIFF
--- a/prophesee_ros_driver/CMakeLists.txt
+++ b/prophesee_ros_driver/CMakeLists.txt
@@ -4,7 +4,16 @@ project(prophesee_ros_driver)
 ## Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++11)
 
-set(OpenCV_DIR /usr/share/OpenCV)
+
+execute_process(COMMAND lsb_release -cs OUTPUT_VARIABLE RELEASE_CODENAME OUTPUT_STRIP_TRAILING_WHITESPACE)
+if ("${RELEASE_CODENAME}" STREQUAL  "bionic")
+	message ("Ubuntu 18.04 found")
+	set(OpenCV_DIR /usr/share/OpenCV)
+elseif ("${RELEASE_CODENAME}" STREQUAL  "xenial")
+	message ("UBUNTU 16.04 found")
+	set(OpenCV_DIR /usr/local/share/OpenCV)
+endif ()
+
 find_package(catkin REQUIRED COMPONENTS
         OpenCV
         roscpp


### PR DESCRIPTION
OpenCV installation for prophesee driver have different flavor, depending on Ubuntu version :
Ubuntu 16.04 use a backported version, installed on /usr/local/share
Ubuntu 18.04 use the official version coming from ubuntu repositories

the aim of this fix is to test the ubuntu version using lsb_release command, to set the good OpenCV path