### PR TITLE
Activity filter and dynamic event rate (max event and streaming rate) parameters

### DIFF
--- a/prophesee_ros_driver/CMakeLists.txt
+++ b/prophesee_ros_driver/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(prophesee_ros_driver)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 
 
 execute_process(COMMAND lsb_release -cs OUTPUT_VARIABLE RELEASE_CODENAME OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/prophesee_ros_driver/cfg/gen3_low_sensitive_settings.bias
+++ b/prophesee_ros_driver/cfg/gen3_low_sensitive_settings.bias
@@ -1,0 +1,29 @@
+% subsystem_ID 2415920387
+% system_ID 21
+300        %   bias_latchout_or_pu       %   v    
+100        %   bias_reqx_or_pu           %   v    
+1200       %   bias_req_pux              %   v    
+1300       %   bias_req_puy              %   v    
+500        %   bias_del_reqx_or          %   v    
+800        %   bias_sendreq_pdx          %   v    
+500        %   bias_sendreq_pdy          %   v    
+400        %   bias_del_ack_array        %   v    
+200        %   bias_del_timeout          %   v    
+400        %   bias_inv                  %   v    
+1500       %   bias_refr                 %   v    
+500        %   bias_clk                  %   v    
+1800       %   bias_hpf                  %   v    
+430        %   bias_tail                 %   i    
+230        %   bias_out                  %   i    
+370        %   bias_hyst                 %   i    
+1397       %   bias_vrefl                %   v    
+1700       %   bias_vrefh                %   v    
+1000       %   bias_cas                  %   v    
+191        %   bias_diff_off             %   v    
+439        %   bias_diff_on              %   v    
+300        %   bias_diff                 %   v    
+1720       %   bias_fo                   %   v    
+1500       %   bias_pr                   %   v    
+1500       %   bias_bulk                 %   v    
+1600       %   bias_overflow             %   v    
+200        %   bias_buf                  %   v    

--- a/prophesee_ros_driver/cfg/gen3_lower_bg_noise.bias
+++ b/prophesee_ros_driver/cfg/gen3_lower_bg_noise.bias
@@ -1,0 +1,29 @@
+% subsystem_ID 2415920387
+% system_ID 21
+300        %   bias_latchout_or_pu       %   v    
+100        %   bias_reqx_or_pu           %   v    
+1200       %   bias_req_pux              %   v    
+1300       %   bias_req_puy              %   v    
+500        %   bias_del_reqx_or          %   v    
+800        %   bias_sendreq_pdx          %   v    
+500        %   bias_sendreq_pdy          %   v    
+400        %   bias_del_ack_array        %   v    
+200        %   bias_del_timeout          %   v    
+400        %   bias_inv                  %   v    
+1500       %   bias_refr                 %   v    
+500        %   bias_clk                  %   v    
+1800       %   bias_hpf                  %   v    
+430        %   bias_tail                 %   i    
+230        %   bias_out                  %   i    
+370        %   bias_hyst                 %   i    
+1397       %   bias_vrefl                %   v    
+1700       %   bias_vrefh                %   v    
+1000       %   bias_cas                  %   v    
+213        %   bias_diff_off             %   v    
+411        %   bias_diff_on              %   v    
+300        %   bias_diff                 %   v    
+1720       %   bias_fo                   %   v    
+1500       %   bias_pr                   %   v    
+1500       %   bias_bulk                 %   v    
+1600       %   bias_overflow             %   v    
+200        %   bias_buf                  %   v    

--- a/prophesee_ros_driver/include/prophesee_ros_driver/prophesee_ros_publisher.h
+++ b/prophesee_ros_driver/include/prophesee_ros_driver/prophesee_ros_publisher.h
@@ -10,6 +10,7 @@
 #include <sensor_msgs/CameraInfo.h>
 
 #include <prophesee_driver.h>
+#include <prophesee_core/algos/core/activity_noise_filter_algorithm.h>
 
 #include "log_tone_mapper.h"
 
@@ -61,6 +62,16 @@ private:
     /// Used to access data from a camera
     Prophesee::Camera camera_;
 
+    /// \brief Instance of Events Array
+    ///
+    /// Accumulated Array of events
+    std::vector<Prophesee::EventCD> event_buffer_;
+
+    /// \brief Frame reconstruction in gray scale
+    ///
+    /// Gray level fram from tone mapper reconstruction
+    cv::Mat graylevel_frame_;
+
     /// \brief Instance of LogToneMapper class
     ///
     /// Used to reconstract gray-levels from CD and EM data and apply tone mapping
@@ -69,14 +80,17 @@ private:
     /// \brief Message for publishing the camera info
     sensor_msgs::CameraInfo cam_info_msg_;
 
+    /// \brief Pointer for the Activity Filter Instance
+    std::shared_ptr< Prophesee::ActivityNoiseFilterAlgorithm<> > activity_filter_;
+
     /// \brief Path to the file with the camera settings (biases)
     std::string biases_file_;
 
     /// \brief Camera name in string format
     std::string camera_name_;
 
-    /// \brief Camera string time
-    ros::Time start_timestamp_;
+    /// \brief Wall time stamps
+    ros::Time start_timestamp_, last_timestamp_;
 
     /// \brief Maximum events rate, in kEv/s
     int max_event_rate_;
@@ -90,10 +104,30 @@ private:
     /// \brief If showing gray-level frames
     bool publish_graylevels_;
 
-   /// \brief If showing IMU events
+    /// \brief If showing IMU events
     bool publish_imu_;
 
-    static constexpr double GRAVITY = 9.81; /** Mean gravity value at Earth surface [m/s^2] **/
+    /// \brief Events rate (configuration)
+    /// Desirable rate in Hz for the events
+    double event_streaming_rate_;
+
+    /// \brief Actvity Filter Temporal depth (configuration)
+    /// Desirable Temporal depth in micro seconds
+    int activity_filter_temporal_depth_;
+
+    /// \brief delta_time for packages cd_events
+    /// Time step for packaging events in an array
+    ros::Duration event_delta_t_;
+
+    /// \brief Event buffer time stamps
+    ros::Time event_buffer_start_time_, event_buffer_current_time_;
+ 
+    /// \brief  Mean gravity value at Earth surface [m/s^2]
+    static constexpr double GRAVITY = 9.81;
+
+    /// \brief delta time of cd events fixed by Prophesee driver
+    /// The delta time is set to a fixed number of 64 microseconds (1e-06)
+    static constexpr double EVENT_DEFAULT_DELTA_T = 6.4e-05;
 };
 
 #endif /* PROPHESEE_ROS_PUBLISHER_H_ */

--- a/prophesee_ros_driver/launch/prophesee_publisher.launch
+++ b/prophesee_ros_driver/launch/prophesee_publisher.launch
@@ -7,13 +7,20 @@
     <param name="publish_imu" value="true" />
 
     <!-- Path to the file with the camera settings -->
-    <param name="bias_file" value="" />
+    <!--param name="bias_file" value="$(find prophesee_ros_driver)/cfg/gen3_low_sensitive_settings.bias" /-->
 
-    <!-- Maximum event rate in kEv/s -->
+    <!-- Maximum event rate in kEv/s. With 0 does not set any limit-->
     <param name="max_event_rate" value="6000" />
+
+    <!-- Streaming rate in Hz for the events array. By default is 64 microsendos or max 100 events in array -->
+    <param name="event_streaming_rate" value="30" />
 
     <!-- Graylevel frame rate in fps -->
     <param name="graylevel_frame_rate" value="30" />
+
+    <!-- Activity filter temporal depth in microseconds -->
+    <param name="activity_filter_temporal_depth" value="0" />
+
   </node>
 
 </launch>

--- a/prophesee_ros_driver/launch/prophesee_publisher.launch
+++ b/prophesee_ros_driver/launch/prophesee_publisher.launch
@@ -19,7 +19,7 @@
     <param name="graylevel_frame_rate" value="30" />
 
     <!-- Activity filter temporal depth in microseconds -->
-    <param name="activity_filter_temporal_depth" value="0" />
+    <!--param name="activity_filter_temporal_depth" value="10000" /-->
 
   </node>
 

--- a/prophesee_ros_driver/launch/prophesee_publisher.launch
+++ b/prophesee_ros_driver/launch/prophesee_publisher.launch
@@ -7,16 +7,16 @@
     <param name="publish_imu" value="true" />
 
     <!-- Path to the file with the camera settings -->
-    <param name="bias_file" value="$(find prophesee_ros_driver)/cfg/gen3_low_sensitive_settings.bias" />
+    <param name="bias_file" value=""/>
 
     <!-- Maximum event rate in kEv/s. With 0 does not set any limit-->
-    <param name="max_event_rate" value="0" />
+    <param name="max_event_rate" value="6000" />
 
     <!-- Streaming rate in Hz for the events array. By default is 64 microsendos or max 100 events in array -->
     <param name="event_streaming_rate" value="0" />
 
     <!-- Graylevel frame rate in fps -->
-    <param name="graylevel_frame_rate" value="0" />
+    <param name="graylevel_frame_rate" value="30" />
 
     <!-- Activity filter temporal depth in microseconds -->
     <param name="activity_filter_temporal_depth" value="0" />

--- a/prophesee_ros_driver/launch/prophesee_publisher.launch
+++ b/prophesee_ros_driver/launch/prophesee_publisher.launch
@@ -7,19 +7,19 @@
     <param name="publish_imu" value="true" />
 
     <!-- Path to the file with the camera settings -->
-    <!--param name="bias_file" value="$(find prophesee_ros_driver)/cfg/gen3_low_sensitive_settings.bias" /-->
+    <param name="bias_file" value="$(find prophesee_ros_driver)/cfg/gen3_low_sensitive_settings.bias" />
 
     <!-- Maximum event rate in kEv/s. With 0 does not set any limit-->
-    <param name="max_event_rate" value="6000" />
+    <param name="max_event_rate" value="0" />
 
     <!-- Streaming rate in Hz for the events array. By default is 64 microsendos or max 100 events in array -->
-    <param name="event_streaming_rate" value="30" />
+    <param name="event_streaming_rate" value="0" />
 
     <!-- Graylevel frame rate in fps -->
-    <param name="graylevel_frame_rate" value="30" />
+    <param name="graylevel_frame_rate" value="0" />
 
     <!-- Activity filter temporal depth in microseconds -->
-    <!--param name="activity_filter_temporal_depth" value="10000" /-->
+    <param name="activity_filter_temporal_depth" value="0" />
 
   </node>
 

--- a/prophesee_ros_driver/src/prophesee_ros_publisher.cpp
+++ b/prophesee_ros_driver/src/prophesee_ros_publisher.cpp
@@ -17,13 +17,17 @@
 
 #include "prophesee_ros_publisher.h"
 
+#include <boost/date_time/posix_time/posix_time.hpp>
+
 PropheseeWrapperPublisher::PropheseeWrapperPublisher():
     nh_("~"),
     biases_file_(""),
     max_event_rate_(6000),
-    graylevel_rate_(30)
+    graylevel_rate_(30),
+    event_streaming_rate_(0),
+    activity_filter_temporal_depth_(10000)
 {
-    camera_name_ = "camera";
+    camera_name_ = "PropheseeCamera_optical_frame";
 
     // Load Parameters
     nh_.getParam("camera_name", camera_name_);
@@ -33,6 +37,8 @@ PropheseeWrapperPublisher::PropheseeWrapperPublisher():
     nh_.getParam("bias_file", biases_file_);
     nh_.getParam("max_event_rate", max_event_rate_);
     nh_.getParam("graylevel_frame_rate", graylevel_rate_);
+    nh_.getParam("event_streaming_rate", event_streaming_rate_);
+    nh_.getParam("activity_filter_temporal_depth", activity_filter_temporal_depth_);
 
     const std::string topic_cam_info = "/prophesee/" + camera_name_ + "/camera_info";
     const std::string topic_cd_event_buffer = "/prophesee/" + camera_name_ + "/cd_events_buffer";
@@ -61,6 +67,18 @@ PropheseeWrapperPublisher::PropheseeWrapperPublisher():
     if (!camera_.set_max_event_rate_limit(max_event_rate_)) {
          ROS_WARN("Failed to set the maximum event rate");
     }
+    
+    /** Read the current stream rate of events **/
+    if (this->event_streaming_rate_ > 0)
+    {
+        this->event_delta_t_.fromNSec(1e09/this->event_streaming_rate_);
+    }
+    else
+    {
+        this->event_delta_t_.fromSec(EVENT_DEFAULT_DELTA_T);
+        this->event_streaming_rate_ = 1.0/this->event_delta_t_.toSec();
+        nh_.setParam("event_streaming_rate", this->event_streaming_rate_);
+    }
 
     // Add camera runtime error callback
     camera_.add_runtime_error_callback(
@@ -71,18 +89,27 @@ PropheseeWrapperPublisher::PropheseeWrapperPublisher():
     auto &geometry = camera_.geometry();
     ROS_INFO("[CONF] Width:%i, Height:%i", geometry.width(), geometry.height());
     ROS_INFO("[CONF] Max event rate, in kEv/s: %u", config.max_drop_rate_limit_kEv_s);
+    ROS_INFO("[CONF] Streaming event array rate, in Hz: %4.2f [%lu microseconds]", this->event_streaming_rate_, this->event_delta_t_.toNSec()/1000);
+    ROS_INFO("[CONF] Activity Filter Temporal depth: %d [microseconds]", this->activity_filter_temporal_depth_);
     ROS_INFO("[CONF] Serial number: %s", config.serial_number.c_str());
 
     // Publish camera info message
     cam_info_msg_.width = geometry.width();
     cam_info_msg_.height = geometry.height();
     cam_info_msg_.header.frame_id = "PropheseeCamera_optical_frame";
+
+    // Set the activity filter instance
+    activity_filter_.reset(new Prophesee::ActivityNoiseFilterAlgorithm<>(camera_.geometry().width(),
+                                                                 camera_.geometry().height(),
+                                                                 activity_filter_temporal_depth_));
 }
 
 PropheseeWrapperPublisher::~PropheseeWrapperPublisher() {
     camera_.stop();
 
     nh_.shutdown();
+
+    activity_filter_.reset();
 }
 
 bool PropheseeWrapperPublisher::openCamera() {
@@ -105,6 +132,7 @@ bool PropheseeWrapperPublisher::openCamera() {
 void PropheseeWrapperPublisher::startPublishing() {
     camera_.start();
     start_timestamp_ = ros::Time::now();
+    last_timestamp_ = start_timestamp_;
 
     if (publish_cd_)
         publishCDEvents();
@@ -112,8 +140,7 @@ void PropheseeWrapperPublisher::startPublishing() {
     if (publish_graylevels_)
         publishGrayLevels();
 
-    if (publish_imu_)
-    {
+    if (publish_imu_){
         /** We need to enable the IMU sensor **/
         camera_.imu_sensor().enable();
 
@@ -122,8 +149,33 @@ void PropheseeWrapperPublisher::startPublishing() {
     }
 
     ros::Rate loop_rate(5);
-    while(ros::ok()) {
-        if (pub_info_.getNumSubscribers() > 0) {
+    while(ros::ok()){
+        /** Get the current max_event_rate (dynamic configuration) **/
+        int new_max_event_rate; 
+        nh_.getParam("max_event_rate", new_max_event_rate);
+        if (new_max_event_rate != max_event_rate_){
+            /** Save the new max event rate **/
+            max_event_rate_ = new_max_event_rate;
+
+            // Set the maximum event rate, in kEv/s
+            if (!camera_.set_max_event_rate_limit(max_event_rate_)){
+                ROS_WARN("Failed to set the maximum event rate");
+            }
+        }
+
+        /** Get the current stream rate of events (dynamic configuration) **/
+        nh_.getParam("event_streaming_rate", event_streaming_rate_);
+        if (this->event_streaming_rate_ > 0){
+            this->event_delta_t_.fromNSec(1e09/this->event_streaming_rate_);
+        }
+        else{
+            this->event_delta_t_.fromSec(EVENT_DEFAULT_DELTA_T);
+            this->event_streaming_rate_ = 1.0/this->event_delta_t_.toSec();
+            nh_.setParam("event_streaming_rate", this->event_streaming_rate_);
+        }
+
+        if (pub_info_.getNumSubscribers() > 0){
+            /** Get and publish camera infor **/
             cam_info_msg_.header.stamp = ros::Time::now();
             pub_info_.publish(cam_info_msg_);
         }
@@ -140,23 +192,48 @@ void PropheseeWrapperPublisher::publishCDEvents() {
                 if (pub_cd_events_.getNumSubscribers() <= 0)
                     return;
 
-                if (ev_begin < ev_end) {
-                    // Define the message for a buffer of CD events
-                    prophesee_event_msgs::EventArray event_buffer_msg;
+                if (ev_begin < ev_end){
+                    // Compute the current local buffer size with new CD events
                     const unsigned int buffer_size = ev_end - ev_begin;
-                    event_buffer_msg.events.resize(buffer_size);
 
-                    // Header Timestamp of the message
-                    event_buffer_msg.header.stamp.fromNSec(start_timestamp_.toNSec() + (ev_begin->t * 1000.00));
+                    // Get the current time
+                    event_buffer_current_time_.fromNSec(start_timestamp_.toNSec() + (ev_begin->t * 1000.00));
+
+                    /** In case the buffer is empty we set the starting time stamp **/
+                    if (event_buffer_.empty()){
+                        // Get starting time
+                        event_buffer_start_time_ = event_buffer_current_time_;
+                    }
+
+                    if (activity_filter_temporal_depth_ > 0){
+                        /** Insert the events to the buffer **/
+                        auto inserter = std::back_inserter(event_buffer_);
+                        activity_filter_->process_output(ev_begin, ev_end, inserter);
+                    }
+
+                    /** Get the last time stamp **/
+                    event_buffer_current_time_.fromNSec(start_timestamp_.toNSec() + (ev_end-1)->t * 1000.00);
+                }
+
+                if ((event_buffer_current_time_ - event_buffer_start_time_) >= event_delta_t_){
+                    /** Create the message **/
+                    prophesee_event_msgs::EventArray event_buffer_msg;
 
                     // Sensor geometry in header of the message
+                    event_buffer_msg.header.stamp = event_buffer_current_time_;
                     event_buffer_msg.height = camera_.geometry().height();
                     event_buffer_msg.width = camera_.geometry().width();
 
-                    // Add events to the message
-                    auto buffer_it = event_buffer_msg.events.begin();
-                    for (const Prophesee::EventCD *it = ev_begin; it != ev_end; ++it, ++buffer_it) {
-                        prophesee_event_msgs::Event &event = *buffer_it;
+                    /** Set the buffer size for the msg **/
+                    event_buffer_msg.events.resize(event_buffer_.size());
+
+                    // Copy the events to the ros buffer format
+                    auto buffer_msg_it = event_buffer_msg.events.begin();
+                    for (const Prophesee::EventCD *it = std::addressof(event_buffer_[0]);
+                                                it != std::addressof(event_buffer_[event_buffer_.size()]);
+                                                ++it, ++buffer_msg_it)
+                    {
+                        prophesee_event_msgs::Event &event = *buffer_msg_it;
                         event.x = it->x;
                         event.y = it->y;
                         event.polarity = it->p;
@@ -166,8 +243,12 @@ void PropheseeWrapperPublisher::publishCDEvents() {
                     // Publish the message
                     pub_cd_events_.publish(event_buffer_msg);
 
-                    ROS_DEBUG("CD data available, buffer size: %d at time: %llu", buffer_size, ev_begin->t);
+                    // Clen the buffer for the next itteration
+                    event_buffer_.clear();
+
+                    ROS_DEBUG("CD data available, buffer size: %d at time: %lui", static_cast<int>(event_buffer_msg.events.size()), event_buffer_msg.header.stamp.toNSec());
                 }
+
             });
     } catch (Prophesee::CameraException &e) {
         ROS_WARN("%s", e.what());
@@ -185,9 +266,9 @@ void PropheseeWrapperPublisher::publishGrayLevels() {
 
             // Define the message for the gray level frame
             cv_bridge::CvImage gl_frame_msg;
-            gl_frame_msg.header.stamp = ros::Time::now();
-            gl_frame_msg.header.frame_id = "PropheseeCamera_optical_frame";
-            gl_frame_msg.encoding = sensor_msgs::image_encodings::TYPE_8UC1;
+            gl_frame_msg.header.stamp = last_timestamp_;
+            gl_frame_msg.header.frame_id = camera_name_;
+            gl_frame_msg.encoding = sensor_msgs::image_encodings::MONO8;
             gl_frame_msg.image = tone_mapper_(f);
 
             // Publish the message
@@ -210,10 +291,6 @@ void PropheseeWrapperPublisher::publishIMUEvents() {
     try {
         Prophesee::CallbackId imu_callback = camera_.imu().add_callback(
             [this](const Prophesee::EventIMU *ev_begin, const Prophesee::EventIMU *ev_end) {
-                // Check the number of subscribers to the topic
-                if (pub_imu_events_.getNumSubscribers() <= 0)
-                    return;
-
                 if (ev_begin < ev_end)
                 {
                     const unsigned int buffer_size = ev_end - ev_begin;
@@ -232,8 +309,14 @@ void PropheseeWrapperPublisher::publishIMUEvents() {
                         imu_sensor_msg.linear_acceleration.y = it->ay * GRAVITY; //IMU y-axis [m/s^2] is pointing up
                         imu_sensor_msg.linear_acceleration.z = it->az * GRAVITY; //IMU z-axis[m/s^2] is pointing forward
 
-                        // Publish the message
-                        pub_imu_events_.publish(imu_sensor_msg);
+                        // Keep track of the most updated timestamp
+                        last_timestamp_ = imu_sensor_msg.header.stamp;
+
+                        if (pub_imu_events_.getNumSubscribers() > 0)
+                        {
+                            // Publish the message
+                            pub_imu_events_.publish(imu_sensor_msg);
+                        }
                     }
 
                     ROS_DEBUG("IMU data available, buffer size: %d at time: %llu", buffer_size, ev_begin->t);


### PR DESCRIPTION
Please have a look at the PR with the recent changes:
* Activity filter in CD events callback
* Dynamic ros parameters for max_event_rate and event_streaming_rate
* CMake with C++14 from prophesee-driver-dev deb package
* More bias files in cfg folder