### PR TITLE
initialize event_delta_t

### DIFF
--- a/prophesee_ros_driver/launch/prophesee_publisher.launch
+++ b/prophesee_ros_driver/launch/prophesee_publisher.launch
@@ -10,6 +10,10 @@
     <!-- Instead of live camera, you can read data offline from raw file -->
     <param name="raw_file_to_read" value="" />
 
+    <!-- approximate time span in seconds for which events will
+	 be aggregated until a ROS message is generated. Defaults to
+	 100 usec -->
+    <param name="event_delta_t" value="0.000100" />
   </node>
 
 </launch>

--- a/prophesee_ros_driver/src/prophesee_ros_publisher.cpp
+++ b/prophesee_ros_driver/src/prophesee_ros_publisher.cpp
@@ -30,6 +30,7 @@ PropheseeWrapperPublisher::PropheseeWrapperPublisher() :
     nh_.getParam("publish_cd", publish_cd_);
     nh_.getParam("bias_file", biases_file_);
     nh_.getParam("raw_file_to_read", raw_file_to_read_);
+    event_delta_t_ = ros::Duration(nh_.param<double>("event_delta_t", 100.0e-6));
 
     const std::string topic_cam_info        = "/prophesee/" + camera_name_ + "/camera_info";
     const std::string topic_cd_event_buffer = "/prophesee/" + camera_name_ + "/cd_events_buffer";


### PR DESCRIPTION
The variable event_delta_t_ appears to be uninitialized and so defaults to zero. This means any callback from the metavision SDK results in a ROS message. The gen3 sensor with 640x480 and a maximum of 50Mevs/s delivers 320 events per callback, which translates to about 150000 ROS messages/sec. This overloads the ROS infrastructure when for instance recording (rosbag record) or displaying events. This occurs even on brand new high end laptops.

This PR makes the message window configurable and defaults it 100usec, resulting in ROS message sizes of 5000 events under full load on a camera with max of 50Mev/s.