### PR TITLE
Fix optimization option for compiling the driver

### DIFF
--- a/prophesee_ros_driver/CMakeLists.txt
+++ b/prophesee_ros_driver/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(prophesee_ros_driver)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++14)
+add_compile_options(-std=c++14 -O3)
 
 
 execute_process(COMMAND lsb_release -cs OUTPUT_VARIABLE RELEASE_CODENAME OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
The prophesee_ros_driver is not optimized by default during compilation, leading to large delays with a live camera.
Simply adding the -O3 compilation option in the CMakeLists.txt fixes the issue.

This should also solve https://github.com/prophesee-ai/prophesee_ros_wrapper/issues/24