### PR TITLE
curl added in CMake files for the driver.

### DIFF
--- a/prophesee_ros_driver/CMakeLists.txt
+++ b/prophesee_ros_driver/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(
     prophesee_ros_publisher
     MetavisionSDK::stream
     ${catkin_LIBRARIES}
+    curl
 )
 
 add_dependencies(
@@ -70,10 +71,12 @@ target_link_libraries(
     prophesee_ros_viewer
     MetavisionSDK::stream
     ${catkin_LIBRARIES}
+    curl
 )
 
 add_dependencies(
     prophesee_ros_viewer
     prophesee_event_msgs_generate_messages_cpp
     ${catkin_EXPORTED_TARGETS}
+    curl
 )


### PR DESCRIPTION
Had compile issues in ubuntu 22.04 with ROS Noetic (using [Robostack](https://robostack.github.io/index.html)). They seemed like linking errors with "curl". Added a few lines in CMakeLists for the ros_driver and it work for me.